### PR TITLE
refactor: User, Creator 도메인 분리

### DIFF
--- a/src/main/java/leets/crazyform/domain/creator/presentation/CreatorController.java
+++ b/src/main/java/leets/crazyform/domain/creator/presentation/CreatorController.java
@@ -60,7 +60,6 @@ public class CreatorController {
         return jwt;
     }
 
-
     @Operation(summary = "설문제작자 토큰갱신", description = "AccessToken을 갱신합니다. 이 때 Cookie에 있는 RefreshToken을 자동으로 가져와 사용합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = JwtResponse.class))),

--- a/src/main/java/leets/crazyform/domain/creator/presentation/dto/SignupRequest.java
+++ b/src/main/java/leets/crazyform/domain/creator/presentation/dto/SignupRequest.java
@@ -2,6 +2,7 @@ package leets.crazyform.domain.creator.presentation.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +15,7 @@ public class SignupRequest {
     private String email;
 
     @NotBlank
+    @Size(min = 8)
     private String password;
 
     @NotBlank

--- a/src/main/java/leets/crazyform/domain/creator/usecase/CreatorSignupImpl.java
+++ b/src/main/java/leets/crazyform/domain/creator/usecase/CreatorSignupImpl.java
@@ -22,7 +22,7 @@ public class CreatorSignupImpl implements CreatorSignup {
     @Transactional
     @Override
     public JwtResponse execute(String email, String password, String nickname) throws EmailDuplicateException, PasswordInvalidException {
-        if (creatorRepository.findByEmail(email).isPresent()) {
+        if (creatorRepository.existsByEmail(email)) {
             throw new EmailDuplicateException();
         }
 

--- a/src/main/java/leets/crazyform/domain/creator/usecase/CreatorSignupImpl.java
+++ b/src/main/java/leets/crazyform/domain/creator/usecase/CreatorSignupImpl.java
@@ -8,12 +8,10 @@ import leets.crazyform.global.jwt.AuthRole;
 import leets.crazyform.global.jwt.JwtProvider;
 import leets.crazyform.global.jwt.dto.JwtResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @RequiredArgsConstructor
 @Service
 public class CreatorSignupImpl implements CreatorSignup {
@@ -24,24 +22,16 @@ public class CreatorSignupImpl implements CreatorSignup {
     @Transactional
     @Override
     public JwtResponse execute(String email, String password, String nickname) throws EmailDuplicateException, PasswordInvalidException {
-        // 이메일 중복 체크
         if (creatorRepository.findByEmail(email).isPresent()) {
             throw new EmailDuplicateException();
         }
 
-        // 패스워드 유효성 체크
-//        if (!password.matches("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*#?&]{8,}$")) {
-//            throw new PasswordInvalidException();
-//        }
-
-        // User 객체 생성
         Creator creator = Creator.builder()
                 .email(email)
                 .nickname(nickname)
                 .password(passwordEncoder.encode(password))
                 .build();
 
-        // User 객체 저장
         creatorRepository.save(creator);
 
         String accessToken = jwtProvider.generateToken(creator.getEmail(), AuthRole.ROLE_CREATOR, false);

--- a/src/main/java/leets/crazyform/global/auth/AuthDetails.java
+++ b/src/main/java/leets/crazyform/global/auth/AuthDetails.java
@@ -1,4 +1,4 @@
-package leets.crazyform.global.jwt.detail;
+package leets.crazyform.global.auth;
 
 import leets.crazyform.global.jwt.AuthRole;
 import lombok.AllArgsConstructor;
@@ -6,32 +6,18 @@ import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 
 @Getter
 @AllArgsConstructor
-public class OAuthDetails implements UserDetails, OAuth2User {
+public class AuthDetails implements UserDetails {
     private final String email;
-    private final String name;
-    private final Map<String, Object> attributes;
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public Map<String, Object> getAttributes() {
-        return attributes;
-    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(new SimpleGrantedAuthority(AuthRole.ROLE_USER.getRole()));
+        return Collections.singletonList(new SimpleGrantedAuthority(AuthRole.ROLE_CREATOR.getRole()));
     }
 
     @Override
@@ -41,7 +27,7 @@ public class OAuthDetails implements UserDetails, OAuth2User {
 
     @Override
     public String getUsername() {
-        return email;
+        return this.email;
     }
 
     @Override

--- a/src/main/java/leets/crazyform/global/auth/AuthDetailsService.java
+++ b/src/main/java/leets/crazyform/global/auth/AuthDetailsService.java
@@ -1,4 +1,4 @@
-package leets.crazyform.global.jwt.detail;
+package leets.crazyform.global.auth;
 
 import leets.crazyform.domain.creator.domain.Creator;
 import leets.crazyform.domain.creator.repository.CreatorRepository;

--- a/src/main/java/leets/crazyform/global/jwt/JwtProvider.java
+++ b/src/main/java/leets/crazyform/global/jwt/JwtProvider.java
@@ -1,7 +1,7 @@
 package leets.crazyform.global.jwt;
 
 import io.jsonwebtoken.*;
-import leets.crazyform.global.jwt.detail.AuthDetailsService;
+import leets.crazyform.global.auth.AuthDetailsService;
 import leets.crazyform.global.jwt.exception.ExpiredTokenException;
 import leets.crazyform.global.jwt.exception.InvalidTokenException;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/leets/crazyform/global/oauth/OAuthDetailService.java
+++ b/src/main/java/leets/crazyform/global/oauth/OAuthDetailService.java
@@ -1,4 +1,4 @@
-package leets.crazyform.global.jwt.detail;
+package leets.crazyform.global.oauth;
 
 import leets.crazyform.domain.user.domain.User;
 import leets.crazyform.domain.user.repository.UserRepository;

--- a/src/main/java/leets/crazyform/global/oauth/OAuthDetails.java
+++ b/src/main/java/leets/crazyform/global/oauth/OAuthDetails.java
@@ -1,4 +1,4 @@
-package leets.crazyform.global.jwt.detail;
+package leets.crazyform.global.oauth;
 
 import leets.crazyform.global.jwt.AuthRole;
 import lombok.AllArgsConstructor;
@@ -6,18 +6,32 @@ import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 @Getter
 @AllArgsConstructor
-public class AuthDetails implements UserDetails {
+public class OAuthDetails implements UserDetails, OAuth2User {
     private final String email;
+    private final String name;
+    private final Map<String, Object> attributes;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(new SimpleGrantedAuthority(AuthRole.ROLE_CREATOR.getRole()));
+        return Collections.singletonList(new SimpleGrantedAuthority(AuthRole.ROLE_USER.getRole()));
     }
 
     @Override
@@ -27,7 +41,7 @@ public class AuthDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return this.email;
+        return email;
     }
 
     @Override

--- a/src/main/java/leets/crazyform/global/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/leets/crazyform/global/oauth/OAuthSuccessHandler.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import leets.crazyform.global.jwt.AuthRole;
 import leets.crazyform.global.jwt.JwtProvider;
-import leets.crazyform.global.jwt.detail.OAuthDetails;
 import leets.crazyform.global.jwt.dto.JwtResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/leets/crazyform/global/security/WebSecurityConfig.java
+++ b/src/main/java/leets/crazyform/global/security/WebSecurityConfig.java
@@ -3,7 +3,7 @@ package leets.crazyform.global.security;
 import leets.crazyform.global.filter.ExceptionHandleFilter;
 import leets.crazyform.global.jwt.JwtFilter;
 import leets.crazyform.global.jwt.JwtProvider;
-import leets.crazyform.global.jwt.detail.OAuthDetailService;
+import leets.crazyform.global.oauth.OAuthDetailService;
 import leets.crazyform.global.oauth.OAuthSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,7 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: kakao_account
+
 jwt:
   access_secret: ${JWT_ACCESS_SECRET}
   refresh_secret: ${JWT_REFRESH_SECRET}


### PR DESCRIPTION
## 중요
**기존에 합쳐져있던 설문참여자와 제작자를 분리하는 작업으로 코드 구조로 많이 변경되었습니다.**

## 추가된 점 또는 변경된 점
- 설문제작자 `Creator` 도메인을 추가했습니다.
- 기존 `User`를 `User`와 `Creator`로 분리했습니다.
- 소셜로그인 관련 로직은 `oauth` 폴더로, 일반로그인 관련 로직은 `auth` 폴더로 이동했습니다.
- 필요없는 주석을 삭제하고 파일 포맷을 정리했습니다.

## 주의사항 및 참고사항
- 계정 리팩토링으로 충돌이 예상됩니다.